### PR TITLE
Fixed typo in description for C++ Shape Example tool.

### DIFF
--- a/cpp_gems/ShapeExample/Code/Source/ShapeExampleWidget.cpp
+++ b/cpp_gems/ShapeExample/Code/Source/ShapeExampleWidget.cpp
@@ -37,7 +37,7 @@ namespace ShapeExample
         mainLayout->setSpacing(20);
 
         // Introduction text explaining the example
-        QLabel* introText = new QLabel(QObject::tr("Welcome to the Python Shape Example tool. This tool demonstrates an example of creating an entity with a shape component in the editor. It also has other functional samples for you to play with."), this);
+        QLabel* introText = new QLabel(QObject::tr("Welcome to the C++ Shape Example tool. This tool demonstrates an example of creating an entity with a shape component in the editor. It also has other functional samples for you to play with."), this);
         introText->setWordWrap(true);
         mainLayout->addWidget(introText);
 


### PR DESCRIPTION
Fixed copy pasta in description when updating the shape examples (replaced `Python` with `C++`)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>