### PR TITLE
Fixed the Python Shape Example to have QtForPython gem as a dependency.

### DIFF
--- a/py_gems/PyShapeExample/Code/CMakeLists.txt
+++ b/py_gems/PyShapeExample/Code/CMakeLists.txt
@@ -46,6 +46,8 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 Gem::PyShapeExample.Editor.Static
+        RUNTIME_DEPENDENCIES
+            Gem::QtForPython.Editor
     )
 
     # By default, we will specify that the above target PyShapeExample would be used by

--- a/py_gems/PyShapeExample/gem.json
+++ b/py_gems/PyShapeExample/gem.json
@@ -4,7 +4,7 @@
     "license": "What license PyShapeExample uses goes here: i.e. https://opensource.org/licenses/MIT",
     "origin": "The primary repo for PyShapeExample goes here: i.e. http://www.mydomain.com",
     "type": "Code",
-    "summary": "A short description of PyShapeExample.",
+    "summary": "Day 1 example of a custom tool in Python that can create shapes in the Editor.",
     "canonical_tags": [
         "Gem"
     ],
@@ -13,5 +13,8 @@
     ],
     "icon_path": "preview.png",
     "requirements": "",
-    "restricted_name": "PyShapeExample"
+    "restricted_name": "PyShapeExample",
+    "dependencies": [
+        "QtForPython"
+    ]
 }


### PR DESCRIPTION
Ensure the Python Shape Example sets the `QtForPython` gem as a dependency (see https://github.com/o3de/o3de/pull/5458 for more details).

Also updated the description of the gem.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>