### PR TITLE
Updated Shape Example tools

### DIFF
--- a/cpp_gems/ShapeExample/CMakeLists.txt
+++ b/cpp_gems/ShapeExample/CMakeLists.txt
@@ -6,16 +6,11 @@
 #
 # {END_LICENSE}
 
-set(o3de_gem_path ${CMAKE_CURRENT_LIST_DIR})
-set(o3de_gem_json ${o3de_gem_path}/gem.json)
-o3de_read_json_key(o3de_gem_name ${o3de_gem_json} "gem_name")
-o3de_restricted_path(${o3de_gem_json} o3de_gem_restricted_path)
+set(gem_path ${CMAKE_CURRENT_LIST_DIR})
+set(gem_json ${gem_path}/gem.json)
+o3de_restricted_path(${gem_json} gem_restricted_path gem_parent_relative_path)
 
-ly_get_list_relative_pal_filename(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${o3de_gem_restricted_path}" ${o3de_gem_path} ${o3de_gem_name})
-
-# Now that we have the platform abstraction layer (PAL) folder for this folder, thats where we will find the
-# project cmake for this platform.
-include(${pal_dir}/${PAL_PLATFORM_NAME_LOWERCASE}_gem.cmake)
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
 ly_add_external_target_path(${CMAKE_CURRENT_LIST_DIR}/3rdParty)
 

--- a/cpp_gems/ShapeExample/Code/CMakeLists.txt
+++ b/cpp_gems/ShapeExample/Code/CMakeLists.txt
@@ -8,11 +8,11 @@
 
 # Currently we are in the Code folder: ${CMAKE_CURRENT_LIST_DIR}
 # Get the platform specific folder ${pal_dir} for the current folder: ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME}
-# Note: ly_get_list_relative_pal_filename will take care of the details for us, as this may be a restricted platform
+# Note: o3de_pal_dir will take care of the details for us, as this may be a restricted platform
 #       in which case it will see if that platform is present here or in the restricted folder.
-#       i.e. It could here in our gem : Gems/ShapeExample/Code/Platform/<platorm_name>  or
-#            <restricted_folder>/<platform_name>/Gems/ShapeExample/Code
-ly_get_list_relative_pal_filename(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} ${o3de_gem_restricted_path} ${o3de_gem_path} ${o3de_gem_name})
+#       i.e. It could here in our gem : Gems/${Name}/Code/Platform/<platorm_name>  or
+#            <restricted_folder>/<platform_name>/Gems/${Name}/Code
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
 # Now that we have the platform abstraction layer (PAL) folder for this folder, thats where we will find the
 # traits for this platform. Traits for a platform are defines for things like whether or not something in this gem

--- a/cpp_gems/ShapeExample/Code/Source/ShapeExampleWidget.cpp
+++ b/cpp_gems/ShapeExample/Code/Source/ShapeExampleWidget.cpp
@@ -24,7 +24,7 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 
-#include <ShapeExampleWidget.h>
+#include "ShapeExampleWidget.h"
 
 namespace ShapeExample
 {
@@ -42,7 +42,7 @@ namespace ShapeExample
         mainLayout->addWidget(introText);
 
         // Show link to the actual tutorial for this example
-        QLabel* tutorialLink = new QLabel(QObject::tr("You can learn how to build this example on <a href=\"https://o3de.org/docs/learning-guide/tutorials/custom-tools/shape-example-cpp/\">O3DE Learn.</a>"), this);
+        QLabel* tutorialLink = new QLabel(QObject::tr("You can learn how to build this example on <a href=\"https://www.o3de.org/docs/learning-guide/tutorials/extend-the-editor/shape-example-cpp/\">O3DE Learn.</a>"), this);
         tutorialLink->setTextFormat(Qt::RichText);
         tutorialLink->setOpenExternalLinks(true);
         mainLayout->addWidget(tutorialLink);
@@ -154,6 +154,15 @@ namespace ShapeExample
     void ShapeExampleWidget::CreateEntityWithShapeComponent(const AZ::TypeId& typeId)
     {
         using namespace AzToolsFramework;
+
+        // Make sure a level is open
+        bool isLevelLoaded = false;
+        EditorRequestBus::BroadcastResult(isLevelLoaded, &EditorRequests::IsLevelDocumentOpen);
+        if (!isLevelLoaded)
+        {
+            AZ_Warning("ShapeExample", false, "Make sure a level is loaded before choosing your shape");
+            return;
+        }
 
         // Create a new entity
         AZ::EntityId newEntityId;

--- a/py_gems/PyShapeExample/CMakeLists.txt
+++ b/py_gems/PyShapeExample/CMakeLists.txt
@@ -1,3 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
 
 set(o3de_gem_path ${CMAKE_CURRENT_LIST_DIR})
 set(o3de_gem_json ${o3de_gem_path}/gem.json)

--- a/py_gems/PyShapeExample/Code/CMakeLists.txt
+++ b/py_gems/PyShapeExample/Code/CMakeLists.txt
@@ -1,11 +1,18 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
 
 # Currently we are in the Code folder: ${CMAKE_CURRENT_LIST_DIR}
 # Get the platform specific folder ${pal_dir} for the current folder: ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME}
-# Note: ly_get_list_relative_pal_filename will take care of the details for us, as this may be a restricted platform
+# Note: o3de_pal_dir will take care of the details for us, as this may be a restricted platform
 #       in which case it will see if that platform is present here or in the restricted folder.
-#       i.e. It could here in our gem : Gems/PyShapeExample/Code/Platform/<platorm_name>  or
-#            <restricted_folder>/<platform_name>/Gems/PyShapeExample/Code
-ly_get_list_relative_pal_filename(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} ${o3de_gem_restricted_path} ${o3de_gem_path} ${o3de_gem_name})
+#       i.e. It could here in our gem : Gems/${Name}/Code/Platform/<platorm_name>  or
+#            <restricted_folder>/<platform_name>/Gems/${Name}/Code
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
 # Now that we have the platform abstraction layer (PAL) folder for this folder, thats where we will find the
 # traits for this platform. Traits for a platform are defines for things like whether or not something in this gem

--- a/py_gems/PyShapeExample/Editor/Scripts/pyshapeexample_dialog.py
+++ b/py_gems/PyShapeExample/Editor/Scripts/pyshapeexample_dialog.py
@@ -25,6 +25,12 @@ class PyShapeExampleDialog(QDialog):
         self.add_shape_name_suffix.setEnabled(len(text))
 
     def create_entity_with_shape_component(self, type_id):
+        # Make sure a level is open
+        is_level_loaded = editor.EditorRequestBus(bus.Broadcast, 'IsLevelDocumentOpen')
+        if not is_level_loaded:
+            print("Make sure a level is loaded before choosing your shape")
+            return
+
         # Create a new entity
         new_entity_id = editor.ToolsApplicationRequestBus(bus.Broadcast, 'CreateNewEntity', entity.EntityId())
 
@@ -66,7 +72,7 @@ class PyShapeExampleDialog(QDialog):
         main_layout.addWidget(intro_text)
 
         # Show link to the actual tutorial for this example
-        tutorial_link = QLabel('You can learn how to build this example on <a href="https://o3de.org/docs/learning-guide/tutorials/custom-tools/shape-example-py/">O3DE Learn.</a>', self)
+        tutorial_link = QLabel('You can learn how to build this example on <a href="https://www.o3de.org/docs/learning-guide/tutorials/extend-the-editor/shape-example-py/">O3DE Learn.</a>', self)
         tutorial_link.setTextFormat(Qt.RichText)
         tutorial_link.setOpenExternalLinks(True)
         main_layout.addWidget(tutorial_link)


### PR DESCRIPTION
Fixes https://github.com/o3de/o3de/issues/10213 and sample update of fixing https://github.com/o3de/o3de.org/issues/1758

Several updates/fixes for the Shape Example tools:
- Updated CMakeLists.txt to replace deprecated `ly_get_list_relative_pal_filename` usage with `o3de_pal_dir`
- Added missing license headers in the python example
- Fixed `ShapeExampleWidget.h` (https://github.com/o3de/o3de.org/issues/1758)
- Fixed links in both of the examples to the docs website (the URLs changed slightly)
- Fixed both examples to check if a level is loaded before creating the Entity + shape Component (which will crash if a level isn't loaded), and print a warning if a level isn't loaded (https://github.com/o3de/o3de/issues/10213)

![UpdatedShapeExampleTools](https://user-images.githubusercontent.com/7519264/189218095-39a7d8ed-670d-4809-a77b-98a406276a34.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>