### PR TITLE
Turned into a Remote Gem Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ The examples are spread across several categories, such as:
 * Creating custom tools for extending the Editor (C++ and Python)
 * Atom rendering (Custom Lighting, Vegetation Bending)
 
+## To add this remote repository in Project Manager use the URL
+
+```
+https://raw.githubusercontent.com/o3de/sample-code-gems/main
+```
+
 ## License
 
 For terms please see the LICENSE*.TXT files at the root of this distribution.

--- a/atom_gems/AtomTutorials/gem.json
+++ b/atom_gems/AtomTutorials/gem.json
@@ -5,6 +5,8 @@
     "license_url": "https://github.com/o3de/sample-code-gems/blob/main/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "origin_url": "https://github.com/o3de/sample-code-gems",
+    "origin_uri": "https://github.com/o3de/sample-code-gems/releases/download/1.0/AtomTutorials-1.0.zip",
+    "sha256": "247AC226827AE182ADD08BA9E1E132A80B8B903AD4BBE5A68609514D14AD7641",
     "repo_uri": "https://raw.githubusercontent.com/o3de/sample-code-gems/main/atom_gems/AtomTutorials",
     "last_updated": "2022-09-09",
     "type": "Code",

--- a/cpp_gems/ShapeExample/gem.json
+++ b/cpp_gems/ShapeExample/gem.json
@@ -5,6 +5,8 @@
     "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "origin_url": "https://github.com/o3de/sample-code-gems",
+    "origin_uri": "https://github.com/o3de/sample-code-gems/releases/download/1.0/ShapeExample-1.0.zip",
+    "sha256": "D5250D3E4CC5CAB0BA257B093D621DE310097502593AEE409F75983F26C557A1",
     "repo_uri": "https://raw.githubusercontent.com/o3de/sample-code-gems/main/cpp_gems/ShapeExample",
     "last_updated": "2022-09-09",
     "type": "Code",

--- a/py_gems/PyShapeExample/gem.json
+++ b/py_gems/PyShapeExample/gem.json
@@ -5,6 +5,8 @@
     "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "origin_url": "https://github.com/o3de/sample-code-gems",
+    "origin_uri": "https://github.com/o3de/sample-code-gems/releases/download/1.0/PyShapeExample-1.0.zip",
+    "sha256": "2B1432A6D6151D1707DD19D2D187FDD821CBD4BE4761FD562A1C0374946EE621",
     "repo_uri": "https://raw.githubusercontent.com/o3de/sample-code-gems/main/py_gems/PyShapeExample",
     "last_updated": "2022-09-09",
     "type": "Code",

--- a/repo.json
+++ b/repo.json
@@ -1,0 +1,13 @@
+{
+    "repo_name": "Extending O3DE - Sample Code Gems",
+    "origin": "sample-code-gems",
+    "repo_uri": "https://raw.githubusercontent.com/o3de/sample-code-gems/main",
+    "summary": "A gem repository which holds various example gems of how to extend the O3DE engine.",
+    "additional_info": "See the README.md at the root of this repository for more information",
+    "last_updated": "2022-09-09",
+    "gems": [
+        "https://raw.githubusercontent.com/o3de/sample-code-gems/main/atom_gems/AtomTutorials",
+        "https://raw.githubusercontent.com/o3de/sample-code-gems/main/cpp_gems/ShapeExample",
+        "https://raw.githubusercontent.com/o3de/sample-code-gems/main/py_gems/PyShapeExample"
+    ]
+}


### PR DESCRIPTION
Updated our sample gems repo into a proper Remote Gem Repository. This will allow users to add this repository as a remote repository in the Project Manager and then be able to download gems from it.

- Added `repo.json` config file to describe the gems available in the remote repo
- Updated the `gem.json` files for our current 3 gems to serve up initial release versions https://github.com/o3de/sample-code-gems/releases/tag/1.0

Signed-off-by: Chris Galvan <chgalvan@amazon.com>